### PR TITLE
Update deviantart.js

### DIFF
--- a/content_scripts/sites/deviantart.js
+++ b/content_scripts/sites/deviantart.js
@@ -586,6 +586,9 @@ async function handleDownloads(downloads, options, progress) {
 
 	progress.start('Starting download');
 
+        // fix for double slash "//v1/fill" in URL sometimes
+        downloads[0].url = downloads[0].url.replace('//v1/fill', '/v1/fill');
+
 	let bytes = 0;
 	let total = downloads.length;
 	let results = [];


### PR DESCRIPTION
This is a rudimentary fix to remove the double slash "//v1/fill" happening in newer(?) download URLs when no download button, which returns HTTP error 400.
For example:  https://www.deviantart.com/saver-ag/art/K-871620536 
I edited the script, ran the addon unsigned in firefox developer edition and it seems to work.
I'm sure you'll do a better job fixing it because I'm no javascript developer and I guess you'll know the point where the double slash is formed.