### PR TITLE
Replace modifier

### DIFF
--- a/content/scripts/main.js
+++ b/content/scripts/main.js
@@ -541,6 +541,15 @@ function renderTemplate(template, type, ...metas) {
                 return value.slice(start, end);
             },
         },
+        // replace
+        {
+            re: /(.+?)\/(.*?)\//,
+            fn: (value, re) => {
+                const old = re[1] ? String(re[1]) : undefined;
+                const _new = re[2] ? String(re[2]) : '';
+                return value.replaceAll(old, _new);
+            },
+        },
     ];
     const mod_regex = new RegExp(`!(${mods.map((mod) => mod.re.source).join('|')})`, 'g');
     let text = template.replace(/{([a-zA-Z]+)(\^)?(?:!.+?)?}/g, (match, p1, p2) => {

--- a/content/scripts/main.js
+++ b/content/scripts/main.js
@@ -545,9 +545,15 @@ function renderTemplate(template, type, ...metas) {
         {
             re: /(.+?)\/(.*?)\//,
             fn: (value, re) => {
-                const old = re[1] ? String(re[1]) : undefined;
+                const old = re[1] ? (re[1].startsWith('r:') ? new RegExp(re[1].slice(2), 'g') : String(re[1])) : undefined;
                 const _new = re[2] ? String(re[2]) : '';
-                return value.replaceAll(old, _new);
+                if (typeof old == 'string') {
+                    return value.replaceAll(old, _new);
+                } else if (old instanceof RegExp) {
+                    return value.replace(old, _new);
+                } else {
+                    return value;
+                }
             },
         },
     ];


### PR DESCRIPTION
Adds a replace modifier, also closes my earlier FR #72. Initial tests appeared fine, didn't interfere with path logic (at least on my end), and didn't replace content outside of the assigned meta. Format for basic string replacement is `!<old>/<new>/`, and for RegExp the format is `!r:<RegExp>/<new>/`. The RegExp is mainly there to ensure a bit more freedom for people that want specificity. 

Seemed to work without issue with stringing replacements back to back, both RegExp and not. Grouping and referencing groups is also possible, of course. Tried making the handling a bit more graceful, might be redundant, but hopefully should catch edge cases. Example usage:
* `{userId!r:(foo)\d{2}/$1X/` would replace `foo48` with `fooX`
* `{userId!abc/A/` would replace `abc` with `A`
* `{title!r:[^a-zA-Z0-9]+/X/}` would replace `落書き` in a title with `X` (and *shouldn't* conflict with slice)