### PR TITLE
Fix lib imports

### DIFF
--- a/src/workers/ugoira_worker.ts
+++ b/src/workers/ugoira_worker.ts
@@ -1,5 +1,7 @@
 addEventListener('message', async (message: MessageEvent<UgoiraWorkerSend>) => {
+    asLog('info', 'Got message for UgoiraWorker');
     const { type, blobs, delays, width, height, ext } = message.data;
+    asLog('info', `UgoiraWorker requested for type ${type}`)
     try {
         let result: Blob;
         switch (type) {
@@ -18,8 +20,10 @@ addEventListener('message', async (message: MessageEvent<UgoiraWorkerSend>) => {
             default:
                 throw new Error('Unknown ugoira convert type');
         }
+        asLog('info', 'UgoiraWorker succeeded. Returning now.');
         postMessage({ message: 'result', result } satisfies UgoiraWorkerResponse);
     } catch (error) {
+        asLog('error', `UgoiraWorker failed with reason: ${error.message}`);
         postMessage({ message: 'error', error } satisfies UgoiraWorkerResponse);
     }
 });
@@ -27,24 +31,28 @@ addEventListener('message', async (message: MessageEvent<UgoiraWorkerSend>) => {
 //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
 async function createGIF(blobs: Blob[], delays: number[], width: number, height: number) {
+    asLog('info', 'createGIF called');
+    asLog('debug', 'Attempting to load gif lib');
     importScripts('/libs/gif.js');
+    asLog('debug', 'Successfully loaded gif lib');
 
+    asLog('debug', 'Creating GIF image data now');
     const frames = await createImageDatas(blobs, width, height);
-
+    asLog('info', 'Successfully created GIF image data. Assembling GIF file now.');
     const gif: GIFLib = new GIF({
         workers: 2,
         quality: 10,
         workerScript: '/libs/gif.worker.js',
     });
-
+    asLog('debug', 'GIF object created. Adding frames.');
     for (let i = 0; i < frames.length; i++) {
         gif.addFrame(frames[i], { delay: delays[i] });
     }
-
+    asLog('debug', 'All GIF frames added. Creating promise.');
     const gif_promise = new Promise<Blob>((resolve) => {
         gif.on('finished', resolve);
     });
-
+    asLog('debug', 'Triggering GIF render now');
     gif.render();
     return await gif_promise;
 }
@@ -52,32 +60,46 @@ async function createGIF(blobs: Blob[], delays: number[], width: number, height:
 //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
 async function createAPNG(blobs: Blob[], delays: number[], width: number, height: number) {
+    asLog('info', 'createAPNG called');
+    asLog('debug', 'Attempting to load UZIP and UPNG libs');
     importScripts('/libs/UZIP.js', '/libs/UPNG.js');
+    asLog('debug', 'Successfully loaded UZIP and UPNG libs');
 
+    asLog('debug', 'Attempting to create APNG image datas');
     const frames = await createImageDatas(blobs, width, height);
+    asLog('info', 'Successfully created APNG image datas');
 
     const array_buffers = frames.map((f) => f.data);
 
+    asLog('debug', 'Encoding PNG now');
     const apng = UPNG.encode(array_buffers, width, height, 0, delays) as Uint8Array<ArrayBuffer>;
+    asLog('info', 'Successfully encoded PNG');
     return new Blob([apng], { type: 'image/png' });
 }
 
 //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
 async function createZIP(blobs: Blob[], delays: number[], ext: string) {
+    asLog('info', 'createZIP called');
+    asLog('debug', 'Attempting to load UZIP lib');
     importScripts('/libs/UZIP.js');
+    asLog('debug', 'Successfully loaded UZIP lib');
 
+    asLog('debug', 'Getting ZIP metadata');
     const frame_pad = `${blobs.length}`.length;
     const delay_pad = `${Math.max(...delays)}`.length;
 
+    asLog('debug', 'Assembling ZIP object now');
     const zip_object: Record<string, Uint8Array<ArrayBuffer>> = {};
     for (let i = 0; i < blobs.length; i++) {
         const n = `${i + 1}`.padStart(frame_pad, '0');
         const d = `${delays[i]}`.padStart(delay_pad, '0');
         zip_object[`${n}_${d}ms.${ext}`] = new Uint8Array(await blobs[i].arrayBuffer());
     }
+    asLog('info', 'Successfully assembled ZIP file. Beginning encoding.');
 
     const zip_data = UZIP.encode(zip_object);
+    asLog('info', 'Successfully encoded ZIP data.');
     return new Blob([zip_data], { type: 'application/zip' });
 }
 
@@ -90,18 +112,23 @@ async function createBitmaps(blobs: Blob[], width: number, height: number) {
 //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
 async function createImageDatas(blobs: Blob[], width: number, height: number) {
+    asLog('debug', 'createImageDatas called');
+    asLog('debug', 'Creataing bitmaps');
     const image_bitmaps = await createBitmaps(blobs, width, height);
+    asLog('debug', 'Successfully created bitmaps');
     const canvas = new OffscreenCanvas(width, height);
     const ctx = canvas.getContext('2d');
     if (!ctx) {
         throw new Error('Unable to get offscreen canvas context');
     }
+    asLog('debug', 'Successfully created OffscreenCanvas. Drawing images to canvas now.');
 
     const frames = [];
     for (const image of image_bitmaps) {
         ctx.drawImage(image, 0, 0);
         frames.push(ctx.getImageData(0, 0, width, height));
     }
+    asLog('debug', 'Successfully rendered frames to canvas.')
 
     return frames;
 }
@@ -109,9 +136,14 @@ async function createImageDatas(blobs: Blob[], width: number, height: number) {
 //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
 async function createWEBM(blobs: Blob[], delays: number[], width: number, height: number) {
+    asLog('info', 'createWEBM called');
+    asLog('debug', 'Attempting to load whammy lib');
     importScripts('/libs/whammy.js');
+    asLog('debug', 'Successfully loaded whammy lib');
 
+    asLog('debug', 'Creating WEBM bitmaps');
     const image_bitmaps = await createBitmaps(blobs, width, height);
+    asLog('info', 'Successfully created WEBM bitmaps.');
     const canvas = new OffscreenCanvas(width, height);
     // whammy does not support transparency
     // TODO: use something else
@@ -122,6 +154,7 @@ async function createWEBM(blobs: Blob[], delays: number[], width: number, height
 
     const webm: WhammyLib = new Whammy.Video();
 
+    asLog('debug', 'Rendering WEBM to canvas now');
     // white is the default background color for transparent animations
     ctx.fillStyle = 'white';
     for (let i = 0; i < image_bitmaps.length; i++) {
@@ -131,10 +164,13 @@ async function createWEBM(blobs: Blob[], delays: number[], width: number, height
         const data_url = await blobToDataUrl(blob);
         webm.add(data_url, delays[i]);
     }
+    asLog('info', 'Successfully rendered WEBM frames. Compiling now.')
 
-    return await new Promise<Blob>((resolve) => {
+    const completeWebM = await new Promise<Blob>((resolve) => {
         webm.compile(false, resolve);
     });
+    asLog('info', 'WebM compilation complete.');
+    return completeWebM;
 }
 
 //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -

--- a/src/workers/ugoira_worker.ts
+++ b/src/workers/ugoira_worker.ts
@@ -1,5 +1,4 @@
 addEventListener('message', async (message: MessageEvent<UgoiraWorkerSend>) => {
-    debugger;
     const { type, blobs, delays, width, height, ext } = message.data;
     try {
         let result: Blob;
@@ -28,7 +27,6 @@ addEventListener('message', async (message: MessageEvent<UgoiraWorkerSend>) => {
 //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
 async function createGIF(blobs: Blob[], delays: number[], width: number, height: number) {
-    debugger;
     importScripts('/libs/gif.js');
 
     const frames = await createImageDatas(blobs, width, height);
@@ -54,7 +52,6 @@ async function createGIF(blobs: Blob[], delays: number[], width: number, height:
 //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
 async function createAPNG(blobs: Blob[], delays: number[], width: number, height: number) {
-    debugger;
     importScripts('/libs/UZIP.js', '/libs/UPNG.js');
 
     const frames = await createImageDatas(blobs, width, height);
@@ -68,7 +65,6 @@ async function createAPNG(blobs: Blob[], delays: number[], width: number, height
 //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
 async function createZIP(blobs: Blob[], delays: number[], ext: string) {
-    debugger;
     importScripts('/libs/UZIP.js');
 
     const frame_pad = `${blobs.length}`.length;
@@ -88,14 +84,12 @@ async function createZIP(blobs: Blob[], delays: number[], ext: string) {
 //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
 async function createBitmaps(blobs: Blob[], width: number, height: number) {
-    debugger;
     return await Promise.all(blobs.map((blob) => createImageBitmap(blob, 0, 0, width, height)));
 }
 
 //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
 async function createImageDatas(blobs: Blob[], width: number, height: number) {
-    debugger;
     const image_bitmaps = await createBitmaps(blobs, width, height);
     const canvas = new OffscreenCanvas(width, height);
     const ctx = canvas.getContext('2d');
@@ -115,7 +109,6 @@ async function createImageDatas(blobs: Blob[], width: number, height: number) {
 //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
 async function createWEBM(blobs: Blob[], delays: number[], width: number, height: number) {
-    debugger;
     importScripts('/libs/whammy.js');
 
     const image_bitmaps = await createBitmaps(blobs, width, height);
@@ -147,7 +140,6 @@ async function createWEBM(blobs: Blob[], delays: number[], width: number, height
 //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
 async function blobToDataUrl(blob: Blob) {
-    debugger;
     // using FileReaderSync made the worker get garbage collected?
     return await new Promise<string>((resolve) => {
         const reader = new FileReader();

--- a/src/workers/ugoira_worker.ts
+++ b/src/workers/ugoira_worker.ts
@@ -1,4 +1,5 @@
 addEventListener('message', async (message: MessageEvent<UgoiraWorkerSend>) => {
+    debugger;
     const { type, blobs, delays, width, height, ext } = message.data;
     try {
         let result: Blob;
@@ -27,14 +28,15 @@ addEventListener('message', async (message: MessageEvent<UgoiraWorkerSend>) => {
 //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
 async function createGIF(blobs: Blob[], delays: number[], width: number, height: number) {
-    importScripts('/lib/gif.js');
+    debugger;
+    importScripts('/libs/gif.js');
 
     const frames = await createImageDatas(blobs, width, height);
 
     const gif: GIFLib = new GIF({
         workers: 2,
         quality: 10,
-        workerScript: '/lib/gif.worker.js',
+        workerScript: '/libs/gif.worker.js',
     });
 
     for (let i = 0; i < frames.length; i++) {
@@ -52,7 +54,8 @@ async function createGIF(blobs: Blob[], delays: number[], width: number, height:
 //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
 async function createAPNG(blobs: Blob[], delays: number[], width: number, height: number) {
-    importScripts('/lib/UZIP.js', '/lib/UPNG.js');
+    debugger;
+    importScripts('/libs/UZIP.js', '/libs/UPNG.js');
 
     const frames = await createImageDatas(blobs, width, height);
 
@@ -65,7 +68,8 @@ async function createAPNG(blobs: Blob[], delays: number[], width: number, height
 //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
 async function createZIP(blobs: Blob[], delays: number[], ext: string) {
-    importScripts('/lib/UZIP.js');
+    debugger;
+    importScripts('/libs/UZIP.js');
 
     const frame_pad = `${blobs.length}`.length;
     const delay_pad = `${Math.max(...delays)}`.length;
@@ -84,12 +88,14 @@ async function createZIP(blobs: Blob[], delays: number[], ext: string) {
 //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
 async function createBitmaps(blobs: Blob[], width: number, height: number) {
+    debugger;
     return await Promise.all(blobs.map((blob) => createImageBitmap(blob, 0, 0, width, height)));
 }
 
 //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
 async function createImageDatas(blobs: Blob[], width: number, height: number) {
+    debugger;
     const image_bitmaps = await createBitmaps(blobs, width, height);
     const canvas = new OffscreenCanvas(width, height);
     const ctx = canvas.getContext('2d');
@@ -109,7 +115,8 @@ async function createImageDatas(blobs: Blob[], width: number, height: number) {
 //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
 async function createWEBM(blobs: Blob[], delays: number[], width: number, height: number) {
-    importScripts('/lib/whammy.js');
+    debugger;
+    importScripts('/libs/whammy.js');
 
     const image_bitmaps = await createBitmaps(blobs, width, height);
     const canvas = new OffscreenCanvas(width, height);
@@ -140,6 +147,7 @@ async function createWEBM(blobs: Blob[], delays: number[], width: number, height
 //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
 async function blobToDataUrl(blob: Blob) {
+    debugger;
     // using FileReaderSync made the worker get garbage collected?
     return await new Promise<string>((resolve) => {
         const reader = new FileReader();

--- a/src/workers/ugoira_worker.ts
+++ b/src/workers/ugoira_worker.ts
@@ -1,7 +1,5 @@
 addEventListener('message', async (message: MessageEvent<UgoiraWorkerSend>) => {
-    asLog('info', 'Got message for UgoiraWorker');
     const { type, blobs, delays, width, height, ext } = message.data;
-    asLog('info', `UgoiraWorker requested for type ${type}`)
     try {
         let result: Blob;
         switch (type) {
@@ -20,10 +18,8 @@ addEventListener('message', async (message: MessageEvent<UgoiraWorkerSend>) => {
             default:
                 throw new Error('Unknown ugoira convert type');
         }
-        asLog('info', 'UgoiraWorker succeeded. Returning now.');
         postMessage({ message: 'result', result } satisfies UgoiraWorkerResponse);
     } catch (error) {
-        asLog('error', `UgoiraWorker failed with reason: ${error.message}`);
         postMessage({ message: 'error', error } satisfies UgoiraWorkerResponse);
     }
 });
@@ -31,28 +27,24 @@ addEventListener('message', async (message: MessageEvent<UgoiraWorkerSend>) => {
 //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
 async function createGIF(blobs: Blob[], delays: number[], width: number, height: number) {
-    asLog('info', 'createGIF called');
-    asLog('debug', 'Attempting to load gif lib');
     importScripts('/libs/gif.js');
-    asLog('debug', 'Successfully loaded gif lib');
 
-    asLog('debug', 'Creating GIF image data now');
     const frames = await createImageDatas(blobs, width, height);
-    asLog('info', 'Successfully created GIF image data. Assembling GIF file now.');
+
     const gif: GIFLib = new GIF({
         workers: 2,
         quality: 10,
         workerScript: '/libs/gif.worker.js',
     });
-    asLog('debug', 'GIF object created. Adding frames.');
+
     for (let i = 0; i < frames.length; i++) {
         gif.addFrame(frames[i], { delay: delays[i] });
     }
-    asLog('debug', 'All GIF frames added. Creating promise.');
+
     const gif_promise = new Promise<Blob>((resolve) => {
         gif.on('finished', resolve);
     });
-    asLog('debug', 'Triggering GIF render now');
+
     gif.render();
     return await gif_promise;
 }
@@ -60,46 +52,32 @@ async function createGIF(blobs: Blob[], delays: number[], width: number, height:
 //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
 async function createAPNG(blobs: Blob[], delays: number[], width: number, height: number) {
-    asLog('info', 'createAPNG called');
-    asLog('debug', 'Attempting to load UZIP and UPNG libs');
     importScripts('/libs/UZIP.js', '/libs/UPNG.js');
-    asLog('debug', 'Successfully loaded UZIP and UPNG libs');
 
-    asLog('debug', 'Attempting to create APNG image datas');
     const frames = await createImageDatas(blobs, width, height);
-    asLog('info', 'Successfully created APNG image datas');
 
     const array_buffers = frames.map((f) => f.data);
 
-    asLog('debug', 'Encoding PNG now');
     const apng = UPNG.encode(array_buffers, width, height, 0, delays) as Uint8Array<ArrayBuffer>;
-    asLog('info', 'Successfully encoded PNG');
     return new Blob([apng], { type: 'image/png' });
 }
 
 //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
 async function createZIP(blobs: Blob[], delays: number[], ext: string) {
-    asLog('info', 'createZIP called');
-    asLog('debug', 'Attempting to load UZIP lib');
     importScripts('/libs/UZIP.js');
-    asLog('debug', 'Successfully loaded UZIP lib');
 
-    asLog('debug', 'Getting ZIP metadata');
     const frame_pad = `${blobs.length}`.length;
     const delay_pad = `${Math.max(...delays)}`.length;
 
-    asLog('debug', 'Assembling ZIP object now');
     const zip_object: Record<string, Uint8Array<ArrayBuffer>> = {};
     for (let i = 0; i < blobs.length; i++) {
         const n = `${i + 1}`.padStart(frame_pad, '0');
         const d = `${delays[i]}`.padStart(delay_pad, '0');
         zip_object[`${n}_${d}ms.${ext}`] = new Uint8Array(await blobs[i].arrayBuffer());
     }
-    asLog('info', 'Successfully assembled ZIP file. Beginning encoding.');
 
     const zip_data = UZIP.encode(zip_object);
-    asLog('info', 'Successfully encoded ZIP data.');
     return new Blob([zip_data], { type: 'application/zip' });
 }
 
@@ -112,23 +90,18 @@ async function createBitmaps(blobs: Blob[], width: number, height: number) {
 //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
 async function createImageDatas(blobs: Blob[], width: number, height: number) {
-    asLog('debug', 'createImageDatas called');
-    asLog('debug', 'Creataing bitmaps');
     const image_bitmaps = await createBitmaps(blobs, width, height);
-    asLog('debug', 'Successfully created bitmaps');
     const canvas = new OffscreenCanvas(width, height);
     const ctx = canvas.getContext('2d');
     if (!ctx) {
         throw new Error('Unable to get offscreen canvas context');
     }
-    asLog('debug', 'Successfully created OffscreenCanvas. Drawing images to canvas now.');
 
     const frames = [];
     for (const image of image_bitmaps) {
         ctx.drawImage(image, 0, 0);
         frames.push(ctx.getImageData(0, 0, width, height));
     }
-    asLog('debug', 'Successfully rendered frames to canvas.')
 
     return frames;
 }
@@ -136,14 +109,9 @@ async function createImageDatas(blobs: Blob[], width: number, height: number) {
 //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
 async function createWEBM(blobs: Blob[], delays: number[], width: number, height: number) {
-    asLog('info', 'createWEBM called');
-    asLog('debug', 'Attempting to load whammy lib');
     importScripts('/libs/whammy.js');
-    asLog('debug', 'Successfully loaded whammy lib');
 
-    asLog('debug', 'Creating WEBM bitmaps');
     const image_bitmaps = await createBitmaps(blobs, width, height);
-    asLog('info', 'Successfully created WEBM bitmaps.');
     const canvas = new OffscreenCanvas(width, height);
     // whammy does not support transparency
     // TODO: use something else
@@ -154,7 +122,6 @@ async function createWEBM(blobs: Blob[], delays: number[], width: number, height
 
     const webm: WhammyLib = new Whammy.Video();
 
-    asLog('debug', 'Rendering WEBM to canvas now');
     // white is the default background color for transparent animations
     ctx.fillStyle = 'white';
     for (let i = 0; i < image_bitmaps.length; i++) {
@@ -164,13 +131,10 @@ async function createWEBM(blobs: Blob[], delays: number[], width: number, height
         const data_url = await blobToDataUrl(blob);
         webm.add(data_url, delays[i]);
     }
-    asLog('info', 'Successfully rendered WEBM frames. Compiling now.')
 
-    const completeWebM = await new Promise<Blob>((resolve) => {
+    return await new Promise<Blob>((resolve) => {
         webm.compile(false, resolve);
     });
-    asLog('info', 'WebM compilation complete.');
-    return completeWebM;
 }
 
 //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -

--- a/src/workers/zip_worker.ts
+++ b/src/workers/zip_worker.ts
@@ -1,4 +1,4 @@
-importScripts('/lib/UZIP.js');
+importScripts('/libs/UZIP.js');
 
 addEventListener('message', async (message: MessageEvent<ZipWorkerSend>) => {
     const zip_blob = message.data.blob;


### PR DESCRIPTION
The npm package rewrite (https://github.com/solorey/Art-Saver/commit/58f70e1f4f74ac5db18c534393062b120198fec7) moved `lib` -> `libs`. However, the things that import those did not get appropriately get updated. This breaks saving APNG, WEBM, ZIP, and GIF (notably for Pixiv ugoira). 

This PR updates the import paths to match. 

I also attempted to add detailed logging to make it easier to catch where the issue is but I couldn't figure out how to get the logging method/settings into the workers. Oh well. 